### PR TITLE
Initial state is used if input state is undefined

### DIFF
--- a/src/___test___/immerReducer.test.ts
+++ b/src/___test___/immerReducer.test.ts
@@ -30,3 +30,8 @@ test("reducer result is a different instance", () => {
   const result = reducer(testState, decrement());
   expect(result).not.toBe(testState);
 });
+
+test("initial state is used if input state is undefined", () => {
+  const result = reducer(undefined, decrement());
+  expect(result.counter).toBe(-1);
+});

--- a/src/immerReducer.ts
+++ b/src/immerReducer.ts
@@ -26,8 +26,7 @@ export function immerReducer<TState>(
     return reducer;
   };
 
-  const reducer = (state: TState, action: AnyAction) => {
-    if (!state) return initialState;
+  const reducer = (state: TState = initialState, action: AnyAction) => {
     let caseEntry = cases[action.type];
 
     if (caseEntry) {


### PR DESCRIPTION
When my input state is undefined, immer reducer returns initial state immediately and doesn't handle action. I think it is unexpected behavior.